### PR TITLE
Test that code still runs when loader is used (failing)

### DIFF
--- a/test/message/esm_loader_success.mjs
+++ b/test/message/esm_loader_success.mjs
@@ -1,0 +1,4 @@
+// Flags:  --experimental-loader ./test/fixtures/es-module-loaders/transform-source.mjs
+import '../common/index.mjs';
+import { message } from '../fixtures/es-modules/message.mjs';
+console.log(message);

--- a/test/message/esm_loader_success.out
+++ b/test/message/esm_loader_success.out
@@ -1,0 +1,3 @@
+(node:*) ExperimentalWarning: --experimental-loader is an experimental feature. This feature could change at any time
+(Use `node --trace-warnings ...` to show where the warning was created)
+A MESSAGE


### PR DESCRIPTION
@bmeck sharing this to expand on my comment at https://github.com/nodejs/node/pull/31229, not sure if this test is good enough to add once the issue with the `source` argument is resolved.